### PR TITLE
metaflow 2.19.23

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: true  # [py<310]
+  skip: true  # [win]  # upstream imports fcntl unconditionally; not in upstream classifiers
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - metaflow = metaflow.cmd.main_cli:start

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - metaflow = metaflow.cmd.main_cli:start
-    - metaflow-dev = metaflow.cmd.make_wrapper:main
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,28 +9,26 @@ source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 71dce211c79d6d328d4d0ae8ee7eeee7e1f1eca2bb3b1dd12054f03ce7c30195
 
-
 build:
   number: 0
-  noarch: python
-  entry_points:
-    - metaflow=metaflow.cmd.main_cli:start
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - metaflow = metaflow.cmd.main_cli:start
+    - metaflow-dev = metaflow.cmd.make_wrapper:main
 
 requirements:
   host:
+    - python
     - pip
-    - python {{ python_min }}
     - setuptools
   run:
-    - python >={{ python_min }}
+    - python
     - boto3
     - requests
     - setuptools
 
 test:
-  requires:
-    - python {{ python_min }}
   imports:
     - metaflow
     - metaflow.client
@@ -40,7 +38,10 @@ test:
     - metaflow.plugins
     - metaflow.plugins.aws
     - metaflow.plugins.aws.batch
+  requires:
+    - pip
   commands:
+    - pip check
     - metaflow --help
 
 about:
@@ -48,7 +49,7 @@ about:
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
-  summary: 'Metaflow: More Data Science, Less Engineering'
+  summary: 'Metaflow: More AI and ML, Less Engineering'
   doc_url: https://docs.metaflow.org/
   dev_url: https://github.com/Netflix/metaflow
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,45 @@
 {% set name = "metaflow" %}
-{% set version = "2.7.20" %}
+{% set version = "2.19.23" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fefdb2552fb987b5ca39557e28dddaceb9347af75b95295274f0db0edd8e084a
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 71dce211c79d6d328d4d0ae8ee7eeee7e1f1eca2bb3b1dd12054f03ce7c30195
+
 
 build:
   number: 0
   noarch: python
   entry_points:
-    - metaflow=metaflow.cmd.main_cli:main
-  script: {{ PYTHON }} -m pip install . -vv
+    - metaflow=metaflow.cmd.main_cli:start
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=2.7
+    - python {{ python_min }}
+    - setuptools
   run:
-    - python >=2.7
+    - python >={{ python_min }}
     - boto3
     - requests
     - setuptools
-    - pylint
 
 test:
+  requires:
+    - python {{ python_min }}
   imports:
     - metaflow
     - metaflow.client
     - metaflow.datastore
     - metaflow.datatools
-    - metaflow.metadata
+    - metaflow.metadata_provider
     - metaflow.plugins
     - metaflow.plugins.aws
     - metaflow.plugins.aws.batch
-    - metaflow.plugins.conda
   commands:
     - metaflow --help
 
@@ -52,4 +54,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - mt-ob
+    - saikonen
     - savingoyal


### PR DESCRIPTION
metaflow 2.19.23

**Destination channel:** defaults

### Links

- [PKG-13517](https://anaconda.atlassian.net/browse/PKG-13517)
- [Upstream repository](https://github.com/Netflix/metaflow)
- [Upstream changelog/diff](https://github.com/Netflix/metaflow/compare/2.7.20...2.19.23)
- Conda-forge recipe sourced from: https://github.com/conda-forge/metaflow-feedstock/blob/main/recipe/meta.yaml

### Explanation of changes:

- **Version bump 2.7.20 → 2.19.23** (latest upstream release on PyPI). Recipe re-synced from current conda-forge feedstock as the starting point.
- **Adaptations from conda-forge to defaults:**
  - Drop `noarch: python`; build per-Python with `skip: true  # [py<310]` to match the AnacondaRecipes Python matrix (3.10–3.14).
  - Replace `python_min` jinja idiom with plain `python` pins in host/run/test (defaults does not use `python_min`).
  - Add `pip check` to test commands; add `pip` to test requires.
  - Refresh summary to match upstream (`Metaflow: More AI and ML, Less Engineering`).
- **Skip Windows (`skip: true  # [win]`).** Upstream metaflow does not support Windows: [`setup.py` classifiers](https://github.com/Netflix/metaflow/blob/2.19.23/setup.py#L38-L46) list only `MacOS X` and `POSIX :: Linux`, and [`metaflow/sidecar/sidecar_subprocess.py`](https://github.com/Netflix/metaflow/blob/2.19.23/metaflow/sidecar/sidecar_subprocess.py) imports `fcntl` unconditionally. Eager plugin loading via `resolve_plugins("step_decorator")` causes `import metaflow` to fail on Windows with `ModuleNotFoundError: No module named 'fcntl'`. conda-forge's `noarch: python` build hides this; per-Python builds surface it.
- **Upstream-verified runtime deps:** [`setup.py:74`](https://github.com/Netflix/metaflow/blob/2.19.23/setup.py#L74) declares `install_requires=["requests", "boto3"]`. `setuptools` is kept in run because [`metaflow/cmd/develop/stubs.py:1`](https://github.com/Netflix/metaflow/blob/2.19.23/metaflow/cmd/develop/stubs.py#L1) imports it directly and the vendored click `pkg_resources` import is lazy.

[PKG-13517]: https://anaconda.atlassian.net/browse/PKG-13517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ